### PR TITLE
테이블 컬럼 수정

### DIFF
--- a/CampaignDB_Init_SQL-platform_server-v0.0.2.txt
+++ b/CampaignDB_Init_SQL-platform_server-v0.0.2.txt
@@ -3,51 +3,54 @@
 CREATE database `campaigndb` DEFAULT CHARACTER SET utf8;
 
 CREATE TABLE `app_info` (
-  `id` int(11) NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `title` varchar(500) NOT NULL,
-  `createdAt` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `modifiedAt` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modifiedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `campaign_info` (
-  `id` int(11) NOT NULL,
-  `title` varchar(500) NOT NULL,
-  `url` text CHARACTER SET latin1 NOT NULL,
-  `createdAt` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `modifiedAt` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  `look_date` int(11) NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `title` varchar(500) NOT NULL COMMENT 'ex) 6일 광고 다시 보지 않기',
+  `url` varchar(500) NOT NULL,
+  `ad_expire_day` int(3) NOT NULL,
+  `start_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `end_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modifiedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE `deivce_for_app` (
+CREATE TABLE `device_for_app` (
+  `device_id` int(11) NOT NULL AUTO_INCREMENT,
   `app_id` int(11) NOT NULL,
-  `device_id` int(11) NOT NULL,
-  `createdAt` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `modifiedAt` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`app_id`,`device_id`),
+  `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modifiedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`device_id`),
+  KEY `appID_to_device` (`app_id`),
   CONSTRAINT `appID_to_device` FOREIGN KEY (`app_id`) REFERENCES `app_info` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `location_for_app` (
+  `location_id` int(11) NOT NULL AUTO_INCREMENT,
   `app_id` int(11) NOT NULL,
-  `location_id` int(11) NOT NULL,
-  `title` int(11) NOT NULL,
-  `createdAt` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `modifiedAt` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`app_id`,`location_id`),
+  `title` varchar(500) NOT NULL,
+  `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modifiedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`location_id`),
+  KEY `appID_to_location` (`app_id`),
   CONSTRAINT `appID_to_location` FOREIGN KEY (`app_id`) REFERENCES `app_info` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE `campaign_for_app` (
-  `app_id` int(11) NOT NULL,
+CREATE TABLE `campaign_for_location` (
   `location_id` int(11) NOT NULL,
-  `order` int(11) NOT NULL,
   `campaign_id` int(11) NOT NULL,
-  `createdAt` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `modifiedAt` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`app_id`,`location_id`,`order`,`campaign_id`),
+  `campaign_order` int(2) NOT NULL,
+  `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modifiedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`location_id`,`campaign_id`),
   KEY `campaignID_to_campaign_for_app` (`campaign_id`),
-  CONSTRAINT `appID_locationID_to_campaign_for_app` FOREIGN KEY (`app_id`, `location_id`) REFERENCES `location_for_app` (`app_id`, `location_id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `campaignID_to_campaign_for_app` FOREIGN KEY (`campaign_id`) REFERENCES `campaign_info` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  CONSTRAINT `campaignID_to_campaign_for_app` FOREIGN KEY (`campaign_id`) REFERENCES `campaign_info` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `locationID_to_campaign_for_app` FOREIGN KEY (`location_id`) REFERENCES `location_for_app` (`location_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
1. auto_increment 추가 : 속도 향상.
2. datetime(8byte: 문자형) -> timestamp(4byte:숫자).
3. campaign_for_app -> campaign_for_location : location_for app 테이블과 관계를 생각할 때 변경해야 한다고 판단.
4. 각 테이블에 들어올 값을 예측하여 column 마다 최대 length 조절
   - int(11) -> int(3), text- > varchar(500)

![image](https://user-images.githubusercontent.com/13326991/27130563-c6cbf434-5141-11e7-97f1-5b53ec1b6613.png)
